### PR TITLE
Add develop branch support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build
 on:
   push:
-    branches: [ main ]
+    branches: [ main, develop ]
   pull_request:
 jobs:
   build:
@@ -27,14 +27,14 @@ jobs:
         path: dist/
         retention-days: 7
     - name: Configure AWS Credentials Staging
-      if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/develop'
       uses: aws-actions/configure-aws-credentials@v2
       with:
         role-to-assume: arn:aws:iam::228243989488:role/ci/ci-fingerprint-upload
         role-session-name: ci-fingerprint-upload
         aws-region: ${{ vars.AWS_REGION }}
     - name: Staging Deploy
-      if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/develop'
       working-directory: ./dist
       run: aws s3 cp . s3://cam-cdn-fingerprint-script-staging-origin/ --recursive --exclude "*" --include="fingerprint.*"
     - name: Configure AWS Credentials Production


### PR DESCRIPTION
Only deploy to staging when changes are merged into develop and deploy to production when changes are merged into production

Will change default branch after change is merged to avoid doing this change multiple times