### PR TITLE
trigger invalidation & ensure content type

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,9 @@ jobs:
       - name: Staging Deploy
         if: github.ref == 'refs/heads/develop'
         working-directory: ./dist
-        run: aws s3 cp . s3://cam-cdn-fingerprint-script-staging-origin/ --recursive --exclude "*" --include="fingerprint.js"
+        run: |
+          aws s3 cp . s3://cam-cdn-fingerprint-script-staging-origin/ --recursive --exclude "*" --include="fingerprint.js" --content-type="text/javascript"
+          aws cloudfront create-invalidation --distribution-id E108OSBUN9XAH1 --paths "/*"
       - name: Configure AWS Credentials Production
         if: github.ref == 'refs/heads/main'
         uses: aws-actions/configure-aws-credentials@v2
@@ -47,4 +49,6 @@ jobs:
       - name: Production Deploy
         if: github.ref == 'refs/heads/main'
         working-directory: ./dist
-        run: aws s3 cp . s3://cam-cdn-fingerprint-script-production-origin/ --recursive --exclude "*" --include="fingerprint.js"
+        run: |
+          aws s3 cp . s3://cam-cdn-fingerprint-script-production-origin/ --recursive --exclude "*" --include="fingerprint.js" --content-type="text/javascript"
+          aws cloudfront create-invalidation --distribution-id EWARMLVIQ5QN8 --paths "/*"


### PR DESCRIPTION
Trigger invalidation on deploy to force an origin fresh. Specify the content type to ensure headers are correct and only .js is uploaded now anyway.

Will do some follow up PR's to further change the upload as there appears to have been some manual changes to artefacts which is not ideal given this is a CI driven flow so will look at moving to sync along with holding the deploy till the invalidation is complete.