### PR TITLE
Development deploy hash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,11 +12,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v3
-        if: github.event_name != 'pull_request'
-      - uses: actions/checkout@v3
-        if: github.event_name == 'pull_request'
-        with:
-          ref: ${{ github.head_ref }}
       - uses: actions/setup-node@v3
         with:
           node-version: 18
@@ -42,7 +37,7 @@ jobs:
         if: github.event_name == 'pull_request'
         working-directory: ./dist
         run: |
-          aws s3 cp . s3://cam-cdn-fingerprint-script-development-staging-origin/${GITHUB_SHA}/ --recursive --exclude "*" --include="fingerprint.js" --content-type="text/javascript"
+          aws s3 cp . s3://cam-cdn-fingerprint-script-development-staging-origin/${{github.event.pull_request.head.sha}}/ --recursive --exclude "*" --include="fingerprint.js" --content-type="text/javascript"
       - name: Configure AWS Credentials Staging
         if: github.ref == 'refs/heads/main'
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,11 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v3
+        if: github.event_name != 'pull_request'
+      - uses: actions/checkout@v3
+        if: github.event_name == 'pull_request'
+        with:
+          ref: ${{ github.head_ref }}
       - uses: actions/setup-node@v3
         with:
           node-version: 18


### PR DESCRIPTION
For development deploy take the commit hash of the change that triggered the CI run rather than the merged checkout hash so its easier to figure out what the hash is by looking at the commits in a PR