### PR TITLE
This is resulting in the session ID changing right after bootstrap if the cookie does not already exist

### DIFF
--- a/src/visitors/bootstrap.tsx
+++ b/src/visitors/bootstrap.tsx
@@ -85,11 +85,11 @@ export const bootstrapVisitor = ({
     visitor.id = visitorId
   }
 
-  const { sessionId, endTime } = getSessionIdAndEndTime(getCookie(CnMCookie))
 
   const combinedCookie = buildCookie({ visitorId: visitor.id as string })
   setCookie(CnMCookie, combinedCookie, 365)
 
+  const { sessionId, endTime } = getSessionIdAndEndTime(getCookie(CnMCookie))
   session.id = sessionId
   session.endTime = endTime
   setSession(session)


### PR DESCRIPTION
… 